### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ generator.save('public/sitemap.xml');
 ### Run generator file
 
 ```shell
-yarb run babel-node sitemap.js
+yarn run babel-node sitemap.js
 ```
 
 ## Roadmap


### PR DESCRIPTION
Noticed a typo on line 54: `yarb` instead of `yarn`.